### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/kanakawai-maui/olelo-honua/security/code-scanning/1](https://github.com/kanakawai-maui/olelo-honua/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/node.js.yml` at the workflow root (top-level, alongside `name` and `on`) so it applies to all jobs by default.  
For this CI workflow, the least-privilege baseline is:

- `contents: read`

This is sufficient for `actions/checkout` and typical build/test steps that only read repository content. No imports, methods, or dependencies are needed—just YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
